### PR TITLE
Add libapparmor1 and clean up after apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM gitlab/gitlab-runner
 MAINTAINER Raymond Rutjes <raymond.rutjes@gmail.com>
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -y \
+    curl \
+    libapparmor1 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install docker-compose
 RUN curl -L https://github.com/docker/compose/releases/download/1.4.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose


### PR DESCRIPTION
I had to add `libapparmor1` to get simple-gitlab-runner to work in my environment.

My `docker info`:

```
root@dockerhost:~# docker info
Containers: 14
Images: 143
Storage Driver: zfs
 Zpool: dockerhost
 Zpool Health: ONLINE
 Parent Dataset: dockerhost/docker/layers
 Space Used By Parent: 1117203968
 Space Available: 1912807161344
 Parent Quota: no
 Compression: on
Execution Driver: native-0.2
Logging Driver: json-file
Kernel Version: 3.16.0-4-amd64
Operating System: Debian GNU/Linux 8 (jessie)
CPUs: 8
Total Memory: 31.39 GiB
Name: dockerhost
ID: (elided)
Labels:
 provider=generic
```
